### PR TITLE
(Fixes #13) Bump dependencies, especially doobie 0.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,15 +5,15 @@ name := "aecor-postgres-journal"
 
 organization := "io.aecor"
 
-scalaVersion := "2.12.7"
+scalaVersion := "2.12.8"
 
-lazy val kindProjectorVersion = "0.9.7"
+lazy val kindProjectorVersion = "0.9.10"
 lazy val aecorVersion = "0.18.0"
-lazy val doobieVersion = "0.6.0"
-lazy val scalaCheckVersion = "1.13.4"
-lazy val scalaTestVersion = "3.0.1"
-lazy val scalaCheckShapelessVersion = "1.1.4"
-lazy val catsVersion = "1.4.0"
+lazy val doobieVersion = "0.7.0"
+lazy val scalaCheckVersion = "1.14.0"
+lazy val scalaTestVersion = "3.0.8"
+lazy val scalaCheckShapelessVersion = "1.1.8"
+lazy val catsVersion = "1.6.1"
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("public")


### PR DESCRIPTION
When using doobie 0.6 with ZIO, There's a connection
leakage problem which leads the whole application to deadlock.

Doobie 0.7 provides more resource safety [1] at some
cost of source and binary compatibility breakage. [2]

[1] https://github.com/tpolecat/doobie/blob/series%2F0.7.x/CHANGELOG.md#new-and-noteworthy-for-version-070
[2] https://tpolecat.github.io/doobie/migration.html#upgrading-to-07x-from-06x