### PR TITLE
Support Cross compile for 2.13.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "aecor-postgres-journal"
 
 organization := "io.aecor"
 
-scalaVersion := "2.12.10"
+crossScalaVersions := Seq("2.13.1", "2.12.10")
 
 lazy val kindProjectorVersion = "0.11.0"
 lazy val aecorVersion = "0.19.0"

--- a/src/main/scala/aecor/journal/postgres/Offset.scala
+++ b/src/main/scala/aecor/journal/postgres/Offset.scala
@@ -3,5 +3,5 @@ package aecor.journal.postgres
 final case class Offset(value: Long) extends AnyVal
 
 object Offset {
-  def zero: Offset = Offset(0l)
+  def zero: Offset = Offset(0L)
 }

--- a/src/test/scala/aecor/journal/postgres/PostgresEventJournalTest.scala
+++ b/src/test/scala/aecor/journal/postgres/PostgresEventJournalTest.scala
@@ -123,12 +123,12 @@ class PostgresEventJournalTest extends AnyFunSuite with Matchers with BeforeAndA
     } yield out
 
     val expected = Vector(
-      (Offset(1L), EntityEvent("a", 1l, "1")),
-      (Offset(2L), EntityEvent("a", 2l, "2")),
-      (Offset(3L), EntityEvent("a", 3l, "3")),
-      (Offset(5L), EntityEvent("b", 1l, "b1")),
-      (Offset(6L), EntityEvent("a", 4l, "a4")),
-      (Offset(7L), EntityEvent("b", 2l, "b2"))
+      (Offset(1L), EntityEvent("a", 1L, "1")),
+      (Offset(2L), EntityEvent("a", 2L, "2")),
+      (Offset(3L), EntityEvent("a", 3L, "3")),
+      (Offset(5L), EntityEvent("b", 1L, "b1")),
+      (Offset(6L), EntityEvent("a", 4L, "a4")),
+      (Offset(7L), EntityEvent("b", 2L, "b2"))
     )
 
     assert(x.unsafeRunSync() == expected)
@@ -150,7 +150,7 @@ class PostgresEventJournalTest extends AnyFunSuite with Matchers with BeforeAndA
     } yield out
 
     val expected =
-      Vector((Offset(7L), EntityEvent("b", 2l, "b2")), (Offset(8L), EntityEvent("a", 5l, "a5")))
+      Vector((Offset(7L), EntityEvent("b", 2L, "b2")), (Offset(8L), EntityEvent("a", 5L, "a5")))
 
     assert(x.unsafeRunSync() == expected)
   }


### PR DESCRIPTION
Aecor supports Scala `2.13.0`. This project needs to support Scala `2.13.x`

1. Cross Compile Result: Succeed 
   - Use `sbt + compile`
1. Cross Test code compile Result: Succeed
   - Use `sbt + test:compile`
1. FIxed lower cased long literal marker to upper case
   - `l` to `L`
   - Scala `2.13.1` can't compile it.
